### PR TITLE
python3Packages.moe-kernels: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/python-modules/moe-kernels/default.nix
+++ b/pkgs/python-modules/moe-kernels/default.nix
@@ -14,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "moe-kernels";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "danieldk";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-7XDec7Y5zBfPsoqYTYjNQDfpqjY9E1j/ejqia2N1gME=";
+    hash = "sha256-k3reRjYARqfX6gNeMQGYEvIVlgUIWGQvUmjI4NuSVS4=";
   };
 
   stdenv = cudaPackages.backendStdenv;


### PR DESCRIPTION
**Note:** do not merge before TGI is in sync. The semantics of the `is_full_k` bool is slightly different.