### PR TITLE
feat: add transformers module to pin version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
               outlines
               punica-kernels
               torch
+              transformers
               ;
           };
         };

--- a/overlay.nix
+++ b/overlay.nix
@@ -10,6 +10,9 @@ final: prev: {
   pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
     (
       python-self: python-super: with python-self; {
+        
+        transformers = callPackage ./pkgs/python-modules/transformers { };
+
         attention-kernels = callPackage ./pkgs/python-modules/attention-kernels { };
 
         awq-inference-engine = callPackage ./pkgs/python-modules/awq-inference-engine { };

--- a/pkgs/python-modules/transformers/default.nix
+++ b/pkgs/python-modules/transformers/default.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  fetchFromGitHub,
+  setuptools,
+  regex,
+  huggingface-hub,
+  numpy,
+  safetensors,
+  tokenizers
+}:
+
+buildPythonPackage rec {
+  pname = "transformers";
+
+  ## TODO: prefer using pypi when possible
+  # version = "4.48.2";
+  # src = fetchPypi {
+  #   pname = "transformers";
+  #   inherit version;
+  #   hash = "sha256-3PtzRz5h8i+zNm/iRx7S5Cd57N1JUnob3xk3V0hV1RY=";
+  # };
+
+  version = "latest";
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "transformers";
+    rev = "8d73a38606bc342b370afe1f42718b4828d95aaa";
+    hash = "sha256-MxroG6CWqrcmRS+eFt7Ej87TDOInN15aRPBUcaycKTI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    regex
+    huggingface-hub
+    numpy
+    safetensors
+    tokenizers
+  ];
+
+  meta = {
+    description = "Fetch a specific version of the transformers library";
+  };
+}


### PR DESCRIPTION
This PR add python module for transformers to pin to a specific version. 

Currently this PR points to a recent commit on main to enable qwen2.5 processor support in TGI, however a specific version from a registry would be preferred in the future