### PR TITLE
cutlass_3_8: init at 3.8.0

### DIFF
--- a/pkgs/cutlass/builder.nix
+++ b/pkgs/cutlass/builder.nix
@@ -22,11 +22,6 @@ cudaPackages.backendStdenv.mkDerivation rec {
     inherit hash;
   };
 
-  postPatch = lib.optionalString (lib.versionOlder version "2.11.0") ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "{CMAKE_INSTALL_LIBDIR}/cmake/" "{CMAKE_INSTALL_LIBDIR}/cmake/NvidiaCutlass/"
-  '';
-
   nativeBuildInputs =
     [ cmake ]
     ++ (with cudaPackages; [
@@ -35,6 +30,11 @@ cudaPackages.backendStdenv.mkDerivation rec {
     ]);
 
   buildInputs = [ python3 ] ++ (with cudaPackages; [ cuda_cudart ]);
+
+  postPatch = lib.optionalString (lib.versionOlder version "2.11.0") ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "{CMAKE_INSTALL_LIBDIR}/cmake/" "{CMAKE_INSTALL_LIBDIR}/cmake/NvidiaCutlass/"
+  '';
 
   cmakeFlags = [
     (lib.cmakeBool "CUTLASS_ENABLE_GTEST_UNIT_TESTS" false)

--- a/pkgs/cutlass/default.nix
+++ b/pkgs/cutlass/default.nix
@@ -18,4 +18,9 @@ in
     version = "3.6.0";
     hash = "sha256-FbMVqR4eZyum5w4Dj5qJgBPOS66sTem/qKZjYIK/7sg=";
   };
+
+  cutlass_3_8 = builder {
+    version = "3.8.0";
+    hash = "sha256-oIzlbKRdOh6gp6nRZ8udLSqleBFoFtgM7liCBlHZLOk=";
+  };
 }


### PR DESCRIPTION
Missed in the kernel-builder package integration.