### PR TITLE
python3Packages.kernels: remove Torch dependency

### DIFF
--- a/pkgs/python-modules/kernels/default.nix
+++ b/pkgs/python-modules/kernels/default.nix
@@ -3,7 +3,6 @@
   fetchPypi,
   setuptools,
   huggingface-hub,
-  torch,
 }:
 
 buildPythonPackage rec {
@@ -21,7 +20,6 @@ buildPythonPackage rec {
 
   dependencies = [
     huggingface-hub
-    torch
   ];
 
   pythonImportsCheck = [ "kernels" ];


### PR DESCRIPTION
Torch is not a hard-dependency (and it was causing some issues in kernel-builder).