### PR TITLE
fix: enable torch use_distributed flag for macos

### DIFF
--- a/pkgs/python-modules/torch/source/2_8/default.nix
+++ b/pkgs/python-modules/torch/source/2_8/default.nix
@@ -439,6 +439,10 @@ buildPythonPackage rec {
   USE_MKLDNN = setBool mklDnnSupport;
   USE_MKLDNN_CBLAS = setBool mklDnnSupport;
 
+  # Enable distributed support (c10d, gloo, etc.)
+  # Required for torch.distributed and dependencies like transformers
+  USE_DISTRIBUTED = setBool true;
+
   # Avoid using pybind11 from git submodule
   # Also avoids pytorch exporting the headers of pybind11
   USE_SYSTEM_PYBIND11 = true;

--- a/pkgs/python-modules/torch/source/2_9/default.nix
+++ b/pkgs/python-modules/torch/source/2_9/default.nix
@@ -422,6 +422,10 @@ buildPythonPackage rec {
   USE_MKLDNN = setBool mklDnnSupport;
   USE_MKLDNN_CBLAS = setBool mklDnnSupport;
 
+  # Enable distributed support (c10d, gloo, etc.)
+  # Required for torch.distributed and dependencies like transformers
+  USE_DISTRIBUTED = setBool true;
+
   # Avoid using pybind11 from git submodule
   # Also avoids pytorch exporting the headers of pybind11
   USE_SYSTEM_PYBIND11 = true;


### PR DESCRIPTION
This PR simply adds the `USE_DISTRIBUTED` to the torch modules since `python3.13-compressed-tensors` was failing when rebuilding on macos

build command
```bash
nix build -L .#all
```