### PR TITLE
feat: prefer latest cpp headers

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-compat": {
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762168314,
-        "narHash": "sha256-+DX6mIF47gRGoK0mqkTg1Jmcjcup0CAXJFHVkdUx8YA=",
+        "lastModified": 1762764791,
+        "narHash": "sha256-mWl8rYSYDFWD+zCR0VkBjEjD9jYj1/nlkDOfNNu44NA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "94fc102d2c15d9c1a861e59de550807c65358e1b",
+        "rev": "b549734f6b3ec54bb9a611a4185d11ee31f52ee1",
         "type": "github"
       },
       "original": {

--- a/pkgs/metal-cpp/default.nix
+++ b/pkgs/metal-cpp/default.nix
@@ -6,11 +6,8 @@
 
 stdenv.mkDerivation rec {
   pname = "metal-cpp";
+  version = "26";
 
-  # TODO: update to version 26 when metal compiler support is resolved
-  # version = "26";
-
-  version = "17.4";
   outputs = [
     "out"
     "dev"
@@ -20,9 +17,7 @@ stdenv.mkDerivation rec {
 
   src = fetchzip {
     # TODO: update URL when version is updated
-    # url = "https://developer.apple.com/metal/cpp/files/${pname}_${version}.zip";
-
-    url = "https://developer.apple.com/metal/cpp/files/${pname}_macOS${version}_iOS${version}.zip";
+    url = "https://developer.apple.com/metal/cpp/files/${pname}_${version}.zip";
     hash = "sha256-7n2eI2lw/S+Us6l7YPAATKwcIbRRpaQ8VmES7S8ZjY8=";
     stripRoot = true;
   };


### PR DESCRIPTION
This PR simply prefers the latest version of the metal cpp headers (`26`) as listed here https://developer.apple.com/metal/cpp/